### PR TITLE
clientApi: Modified Swagger documentation

### DIFF
--- a/client/src/businesses/businesses.controller.ts
+++ b/client/src/businesses/businesses.controller.ts
@@ -29,11 +29,7 @@ import { UpdateBusinessDto } from './req-dtos/update-business.dto';
 export class BusinessesController {
   constructor(private readonly businessesService: BusinessesService) {}
 
-  @ApiOperation({
-    summary: 'This route creates a new business',
-    description:
-      "Creates a new business associated to authenticated user's profile",
-  })
+  @ApiOperation({ summary: 'This route creates a new business' })
   @ApiCreatedResponse({
     type: Business,
     description: 'Successfully created business',
@@ -50,7 +46,7 @@ export class BusinessesController {
   })
   @ApiBadRequestResponse({ description: 'Bad Request: Validation error' })
   @ApiForbiddenResponse({
-    description: 'Forbidden: Only owner can perform this action',
+    description: 'Forbidden: Not authorized to perform this action',
   })
   @ApiNotFoundResponse({ description: 'Not Found: Could not find business' })
   @Patch('/:businessId')
@@ -68,9 +64,8 @@ export class BusinessesController {
     type: Business,
     description: 'Successfully removed business',
   })
-  @ApiBadRequestResponse({ description: 'Bad Request: Validation error' })
   @ApiForbiddenResponse({
-    description: 'Forbidden: Only owner can perform this action',
+    description: 'Forbidden: Not authorized to perform this action',
   })
   @ApiNotFoundResponse({ description: 'Not Found: Could not find business' })
   @Delete('/:businessId')
@@ -82,23 +77,7 @@ export class BusinessesController {
     type: Business,
     description: 'Successfully retrieved business',
   })
-  @ApiBadRequestResponse({ description: 'Bad Request: Validation error' })
   @ApiNotFoundResponse({ description: 'Not Found: Could not find business' })
   @Get('/:businessId')
   getBusinessById(@Param('businessId') businessId: string): void {}
-
-  @ApiOperation({ summary: "This route gets a given profile's businesses" })
-  @ApiParam({
-    type: String,
-    name: 'profileId',
-    description: 'Profile id of owner',
-  })
-  @ApiOkResponse({
-    type: [Business],
-    description: 'Successfully retrieved businesses',
-  })
-  @ApiBadRequestResponse({ description: 'Bad Request: Validation error' })
-  @ApiNotFoundResponse({ description: 'Not Found: Could not find business' })
-  @Get('/:profileId')
-  getProfileBusinesses(@Param('profileId') profileId: string): void {}
 }

--- a/client/src/comment_likes/comment_likes.controller.ts
+++ b/client/src/comment_likes/comment_likes.controller.ts
@@ -1,8 +1,6 @@
-import { Controller, Delete, Get, Param, Patch, Post } from '@nestjs/common';
+import { Controller, Delete, Get, Param, Post } from '@nestjs/common';
 import { CommentLikesService } from './comment_likes.service';
 import {
-  ApiBadRequestResponse,
-  ApiConflictResponse,
   ApiCreatedResponse,
   ApiNotFoundResponse,
   ApiOkResponse,
@@ -25,13 +23,7 @@ export class CommentLikesController {
     type: CommentLike,
     description: 'Successfully liked a comment',
   })
-  @ApiBadRequestResponse({
-    description: 'Bad Request: Validation error',
-  })
   @ApiNotFoundResponse({ description: 'Not Found: Could not find comment' })
-  @ApiConflictResponse({
-    description: 'Conflict: Comment has already been liked',
-  })
   @Post('like')
   likeComment(@Param('commentId') commentId: string): void {}
 
@@ -44,33 +36,11 @@ export class CommentLikesController {
     type: CommentLike,
     description: 'Successfully unliked a comment',
   })
-  @ApiBadRequestResponse({
-    description: 'Bad Request: Validation error',
-  })
   @ApiNotFoundResponse({
-    description: 'Not Found: Could not find comment / comment like',
+    description: 'Not Found: Could not find comment',
   })
   @Delete('unlike')
   unlikeComment(@Param('commentId') commentId: string): void {}
-
-  @ApiOperation({
-    summary: 'This route relikes a comment',
-    description: 'Removes soft delete from a comment_like entity',
-  })
-  @ApiParam({ type: String, name: 'commentId', description: 'Comment id' })
-  @ApiOkResponse({
-    type: CommentLike,
-    description: 'Successfully reliked a comment',
-  })
-  @ApiBadRequestResponse({
-    description: 'Bad Request: Validation error',
-  })
-  @ApiNotFoundResponse({
-    description:
-      'Not Found: Could not find comment / soft deleted comment like',
-  })
-  @Patch('relike')
-  relikeComment(@Param('commentId') commentId: string): void {}
 
   @ApiOperation({ summary: "This route gets a comment's likes" })
   @ApiParam({ type: String, name: 'commentId', description: 'Comment id' })
@@ -78,11 +48,8 @@ export class CommentLikesController {
     type: [CommentLike],
     description: 'Successfully retrieved comment likes',
   })
-  @ApiBadRequestResponse({
-    description: 'Bad Request: Validation error',
-  })
   @ApiNotFoundResponse({
-    description: 'Not Found: Could not find comment / comment likes',
+    description: 'Not Found: Could not find comment',
   })
   @Get('likes')
   getCommentLikes(@Param('commentId') commentId: string): void {}

--- a/client/src/comments/comments.controller.ts
+++ b/client/src/comments/comments.controller.ts
@@ -52,10 +52,10 @@ export class CommentsController {
   })
   @ApiBadRequestResponse({ description: 'Bad Request: Validation error' })
   @ApiForbiddenResponse({
-    description: 'Forbidden: Only owner can perform this action',
+    description: 'Forbidden: Not authorized to perform this action',
   })
   @ApiNotFoundResponse({
-    description: 'Not Found: Could not find post / comment',
+    description: 'Not Found: Could not find comment',
   })
   @Patch('/:commentId')
   editComment(
@@ -71,12 +71,11 @@ export class CommentsController {
     type: Comment,
     description: 'Successfully removed the comment',
   })
-  @ApiBadRequestResponse({ description: 'Bad Request: Validation error' })
   @ApiForbiddenResponse({
-    description: 'Forbidden: Only owner can perform this action',
+    description: 'Forbidden: Not authorized to perform this action',
   })
   @ApiNotFoundResponse({
-    description: 'Not Found: Could not find post / comment',
+    description: 'Not Found: Could not find comment',
   })
   @Delete('/:commentId')
   removeComment(
@@ -90,10 +89,7 @@ export class CommentsController {
     type: [Comment],
     description: "Successfully retrieved given post's comments",
   })
-  @ApiBadRequestResponse({ description: 'Bad Request: Validation error' })
-  @ApiNotFoundResponse({
-    description: 'Not Found: Could not find post',
-  })
+  @ApiNotFoundResponse({ description: 'Not Found: Could not find comments' })
   @Get()
   getPostComments(@Param('postId') postId: string): void {}
 
@@ -102,12 +98,9 @@ export class CommentsController {
   @ApiParam({ type: String, name: 'commentId', description: 'Comment id' })
   @ApiOkResponse({
     type: Comment,
-    description: "Successfully retrieved given post's comment",
+    description: 'Successfully retrieved comment',
   })
-  @ApiBadRequestResponse({ description: 'Bad Request: Validation error' })
-  @ApiNotFoundResponse({
-    description: 'Not Found: Could not find post / comment',
-  })
+  @ApiNotFoundResponse({ description: 'Not Found: Could not find comment' })
   @Get('/:commentId')
   getPostComment(
     @Param('postId') postId: string,

--- a/client/src/follows/follows.controller.ts
+++ b/client/src/follows/follows.controller.ts
@@ -1,16 +1,6 @@
-import {
-  Body,
-  Controller,
-  Delete,
-  Get,
-  Param,
-  Patch,
-  Post,
-} from '@nestjs/common';
+import { Controller, Delete, Get, Param, Post } from '@nestjs/common';
 import { FollowsService } from './follows.service';
 import {
-  ApiBadRequestResponse,
-  ApiConflictResponse,
   ApiCreatedResponse,
   ApiNotFoundResponse,
   ApiOkResponse,
@@ -37,14 +27,8 @@ export class FollowsController {
     type: Follow,
     description: 'Successfully created follow entity',
   })
-  @ApiBadRequestResponse({
-    description: 'Bad Request: Validation error',
-  })
   @ApiNotFoundResponse({
     description: 'Not Found: Could not find given profile',
-  })
-  @ApiConflictResponse({
-    description: 'Conflict: Already following profile',
   })
   @Post('follow')
   follow(@Param('profileId') profileId: string): void {}
@@ -59,33 +43,11 @@ export class FollowsController {
     type: Follow,
     description: 'Successfully performed soft deletion on follow',
   })
-  @ApiBadRequestResponse({
-    description: 'Bad Request: Validation error',
-  })
   @ApiNotFoundResponse({
-    description: 'Not Found: Could not find profile / follow',
+    description: 'Not Found: Could not find profile',
   })
   @Delete('unfollow')
   unfollow(@Param('profileId') profileId: string): void {}
-
-  // refollow
-  @ApiOperation({
-    summary: 'This route refollows an unfollowed profile',
-    description: 'Removes a soft delete from a follow entity',
-  })
-  @ApiParam({ type: String, name: 'profileId', description: 'Profile id' })
-  @ApiOkResponse({
-    type: Follow,
-    description: 'Successfully performed refollow',
-  })
-  @ApiBadRequestResponse({
-    description: 'Bad Request: Validation error',
-  })
-  @ApiNotFoundResponse({
-    description: 'Not Found: Could not find profile / soft deleted follow',
-  })
-  @Patch('refollow')
-  refollow(@Param('profileId') profileId: string): void {}
 
   // getFollowers
   @ApiOperation({
@@ -96,11 +58,8 @@ export class FollowsController {
     type: [Follow],
     description: 'Successfully retrieved all followers',
   })
-  @ApiBadRequestResponse({
-    description: 'Bad Request: Validation error',
-  })
   @ApiNotFoundResponse({
-    description: 'Could not find profile / any followers',
+    description: 'Could not find any followers',
   })
   @Get('/followers')
   getFollowers(@Param('profileId') profileId: string): void {}
@@ -114,11 +73,8 @@ export class FollowsController {
     type: [Follow],
     description: 'Successfully retrieved all follows',
   })
-  @ApiBadRequestResponse({
-    description: 'Bad Request: Validation error',
-  })
   @ApiNotFoundResponse({
-    description: 'Could not find profile / any follows',
+    description: 'Could not find any follows',
   })
   @Get('/follows')
   getFollows(@Param('profileId') profileId: string): void {}
@@ -137,11 +93,8 @@ export class FollowsController {
     type: Follow,
     description: 'Successfully retrieved follower',
   })
-  @ApiBadRequestResponse({
-    description: 'Bad Request: Validation error',
-  })
   @ApiNotFoundResponse({
-    description: 'Could not find profile / follower',
+    description: 'Could not find follower',
   })
   @Get('/followers/:followerProfileId')
   getFollowerById(
@@ -163,11 +116,8 @@ export class FollowsController {
     type: Follow,
     description: 'Successfully retrieved follow',
   })
-  @ApiBadRequestResponse({
-    description: 'Bad Request: Validation error',
-  })
   @ApiNotFoundResponse({
-    description: 'Could not find profile / follow',
+    description: 'Could not find follow',
   })
   @Get('/follows/:followedProfileId')
   getFollowById(

--- a/client/src/photos/photos.controller.ts
+++ b/client/src/photos/photos.controller.ts
@@ -3,6 +3,7 @@ import { PhotosService } from './photos.service';
 import {
   ApiBadRequestResponse,
   ApiCreatedResponse,
+  ApiForbiddenResponse,
   ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
@@ -19,26 +20,34 @@ import { CreatePhotoDto } from './req-dtos/create-photo.dto';
 export class PhotosController {
   constructor(private readonly photosService: PhotosService) {}
 
-  @ApiOperation({
-    summary: 'This route creates a new photo entity',
-    description:
-      'The photo entity consists of a url property along with some metadata',
-  })
+  @ApiOperation({ summary: 'This route creates a new photo' })
   @ApiCreatedResponse({
     type: Photo,
-    description: 'Successfully created photo entity',
+    description: 'Successfully created photo',
   })
   @ApiBadRequestResponse({ description: 'Bad Request: Validation error' })
   @Post()
   createPhoto(@Body() createPhotoDto: CreatePhotoDto): void {}
 
-  @ApiOperation({ summary: 'This route gets a photo entity by id' })
+  @ApiOperation({ summary: 'This route deletes a photo' })
   @ApiParam({ type: String, name: 'photoId', description: 'Photo id' })
   @ApiOkResponse({
     type: Photo,
-    description: 'Successfully retrieved photo entity',
+    description: 'Successfully removed photo',
   })
-  @ApiBadRequestResponse({ description: 'Bad Request: Validation error' })
+  @ApiForbiddenResponse({
+    description: 'Forbidden: Not authorized to perform this action',
+  })
+  @ApiNotFoundResponse({ description: 'Not Found: Could not find photo' })
+  @Delete('/:photoId')
+  removePhoto(@Param('photoId') photoId: string): void {}
+
+  @ApiOperation({ summary: 'This route gets a photo by id' })
+  @ApiParam({ type: String, name: 'photoId', description: 'Photo id' })
+  @ApiOkResponse({
+    type: Photo,
+    description: 'Successfully retrieved photo',
+  })
   @ApiNotFoundResponse({ description: 'Not Found: Could not find photo' })
   @Get('/:photoId')
   getPhotoById(@Param('photoId') photoId: string): void {}

--- a/client/src/post_likes/post_likes.controller.ts
+++ b/client/src/post_likes/post_likes.controller.ts
@@ -1,8 +1,6 @@
-import { Controller, Delete, Get, Param, Patch, Post } from '@nestjs/common';
+import { Controller, Delete, Get, Param, Post } from '@nestjs/common';
 import { PostLikesService } from './post_likes.service';
 import {
-  ApiBadRequestResponse,
-  ApiConflictResponse,
   ApiCreatedResponse,
   ApiNotFoundResponse,
   ApiOkResponse,
@@ -25,11 +23,7 @@ export class PostLikesController {
     type: PostLike,
     description: 'Successfully liked a post',
   })
-  @ApiBadRequestResponse({
-    description: 'Bad Request: Validation error',
-  })
   @ApiNotFoundResponse({ description: 'Not Found: Could not find post' })
-  @ApiConflictResponse({ description: 'Conflict: Post has already been liked' })
   @Post('like')
   likePost(@Param('postId') postId: string): void {}
 
@@ -39,29 +33,11 @@ export class PostLikesController {
   })
   @ApiParam({ type: String, name: 'postId', description: 'Post id' })
   @ApiOkResponse({ type: PostLike, description: 'Successfully unliked a post' })
-  @ApiBadRequestResponse({
-    description: 'Bad Request: Validation error',
-  })
   @ApiNotFoundResponse({
-    description: 'Not Found: Could not find post / post like',
+    description: 'Not Found: Could not find post',
   })
   @Delete('unlike')
   unlikePost(@Param('postId') postId: string): void {}
-
-  @ApiOperation({
-    summary: 'This route relikes a post',
-    description: 'Removes soft delete from a post_like entity',
-  })
-  @ApiParam({ type: String, name: 'postId', description: 'Post id' })
-  @ApiOkResponse({ type: PostLike, description: 'Successfully reliked a post' })
-  @ApiBadRequestResponse({
-    description: 'Bad Request: Validation error',
-  })
-  @ApiNotFoundResponse({
-    description: 'Not Found: Could not find post / soft deleted post like',
-  })
-  @Patch('relike')
-  relikePost(@Param('postId') postId: string): void {}
 
   @ApiOperation({ summary: "This route gets a post's likes" })
   @ApiParam({ type: String, name: 'postId', description: 'Post id' })
@@ -69,12 +45,7 @@ export class PostLikesController {
     type: [PostLike],
     description: 'Successfully retrieved post likes',
   })
-  @ApiBadRequestResponse({
-    description: 'Bad Request: Validation error',
-  })
-  @ApiNotFoundResponse({
-    description: 'Not Found: Could not find post / post likes',
-  })
+  @ApiNotFoundResponse({ description: 'Not Found: Could not find post' })
   @Get('likes')
   getPostLikes(@Param('postId') postId: string): void {}
 }

--- a/client/src/post_photos/post_photos.controller.ts
+++ b/client/src/post_photos/post_photos.controller.ts
@@ -2,7 +2,6 @@ import { Body, Controller, Delete, Get, Param, Post } from '@nestjs/common';
 import { PostPhotosService } from './post_photos.service';
 import {
   ApiBadRequestResponse,
-  ApiConflictResponse,
   ApiCreatedResponse,
   ApiForbiddenResponse,
   ApiNotFoundResponse,
@@ -23,8 +22,7 @@ export class PostPhotosController {
 
   @ApiOperation({
     summary: 'This route uploads a post photo',
-    description:
-      'Creates a post_photo entity to relate a post to a photo, post is provided via route parameter',
+    description: 'Creates a post_photo entity to relate a post to a photo',
   })
   @ApiParam({ type: String, name: 'postId', description: 'Post id' })
   @ApiCreatedResponse({
@@ -33,12 +31,9 @@ export class PostPhotosController {
   })
   @ApiBadRequestResponse({ description: 'Bad Request: Validation error' })
   @ApiForbiddenResponse({
-    description: 'Forbidden: Only owner can perform this action',
+    description: 'Forbidden: Not authorized to perform this action',
   })
   @ApiNotFoundResponse({ description: 'Not Found: Could not find post' })
-  @ApiConflictResponse({
-    description: 'Conflict: Post is already associated with given photo id',
-  })
   @Post()
   uploadPostPhoto(
     @Param('postId') postId: string,
@@ -52,12 +47,11 @@ export class PostPhotosController {
   @ApiParam({ type: String, name: 'postId', description: 'Post id' })
   @ApiParam({ type: String, name: 'photoId', description: 'Photo id' })
   @ApiOkResponse({ type: PostPhoto, description: 'Successfully removed photo' })
-  @ApiBadRequestResponse({ description: 'Bad Request: Validation error' })
   @ApiForbiddenResponse({
-    description: 'Forbidden: Only owner can perform this action',
+    description: 'Forbidden: Not authorized to perform this action',
   })
   @ApiNotFoundResponse({
-    description: 'Not Found: Could not find post / photo',
+    description: 'Not Found: Could not find post photo',
   })
   @Delete('/:photoId')
   removePostPhoto(
@@ -71,10 +65,7 @@ export class PostPhotosController {
     type: [PostPhoto],
     description: 'Successfully retrieved post photos',
   })
-  @ApiBadRequestResponse({ description: 'Bad Request: Validation error' })
-  @ApiNotFoundResponse({
-    description: 'Not Found: Could not find post / photos',
-  })
+  @ApiNotFoundResponse({ description: 'Not Found: Could not find post photos' })
   @Get()
   getPostPhotos(@Param('postId') postId: string): void {}
 
@@ -85,10 +76,7 @@ export class PostPhotosController {
     type: PostPhoto,
     description: 'Successfully retrieved photo',
   })
-  @ApiBadRequestResponse({ description: 'Bad Request: Validation error' })
-  @ApiNotFoundResponse({
-    description: 'Not Found: Could not find post / photo',
-  })
+  @ApiNotFoundResponse({ description: 'Not Found: Could not find post photo' })
   @Get('/:photoId')
   getPostPhotoById(
     @Param('postId') postId: string,

--- a/client/src/posts/posts.controller.ts
+++ b/client/src/posts/posts.controller.ts
@@ -50,7 +50,7 @@ export class PostsController {
   })
   @ApiBadRequestResponse({ description: 'Bad Request: Validation error' })
   @ApiForbiddenResponse({
-    description: 'Forbidden: Only owner can perform this action',
+    description: 'Forbidden: Not authorized to perform this action',
   })
   @ApiNotFoundResponse({
     description: "Not Found: Could not find profile's post",
@@ -71,9 +71,8 @@ export class PostsController {
     description: 'Post id',
   })
   @ApiOkResponse({ type: PostEntity, description: 'Successfully removed post' })
-  @ApiBadRequestResponse({ description: 'Bad Request: Validation error' })
   @ApiForbiddenResponse({
-    description: 'Forbidden: Only owner can perform this action',
+    description: 'Forbidden: Not authorized to perform this action',
   })
   @ApiNotFoundResponse({
     description: "Not Found: Could not find profile's post",
@@ -93,7 +92,6 @@ export class PostsController {
     type: [PostEntity],
     description: "Successfully retrieved given profile's posts",
   })
-  @ApiBadRequestResponse({ description: 'Bad Request: Validation error' })
   @ApiNotFoundResponse({
     description: "Not Found: Could not find profile's posts",
   })
@@ -117,7 +115,6 @@ export class PostsController {
     type: PostEntity,
     description: "Successfully retrieved given profile's post",
   })
-  @ApiBadRequestResponse({ description: 'Bad Request: Validation error' })
   @ApiNotFoundResponse({
     description: "Not Found: Could not find profile's post",
   })

--- a/client/src/profiles/profiles.controller.ts
+++ b/client/src/profiles/profiles.controller.ts
@@ -46,9 +46,6 @@ export class ProfilesController {
     type: Profile,
     description: 'Successfully retreived profile',
   })
-  @ApiBadRequestResponse({
-    description: 'Bad Request: Validation error',
-  })
   @ApiNotFoundResponse({
     description: 'Not Found: Could not find profile',
   })
@@ -69,7 +66,7 @@ export class ProfilesController {
     description: 'Bad Request: Validation error',
   })
   @ApiForbiddenResponse({
-    description: 'Forbidden: Only owner can perform this action',
+    description: 'Forbidden: Not authorized to perform this action',
   })
   @ApiNotFoundResponse({
     description: 'Not Found: Could not find profile',


### PR DESCRIPTION
Removed all 400 responses related to route parameters.

Additionally
businesses:
    - removed functionality regarding profile_id
comment_likes & post_likes:
    - Removed 'relike' functionality
    - Removed 409 conflict responses
follows:
    - Removed 'refollow' functionality
    - Removed 409 conflict responses
photos:
    - Added DELETE route